### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kuya-carlo/sgsite/security/code-scanning/1](https://github.com/kuya-carlo/sgsite/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the steps in the workflow, it appears that the workflow primarily reads repository contents and does not require write permissions. Therefore, we will set `contents: read` as the minimal required permission. If additional permissions are needed in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
